### PR TITLE
Fixes JGDoerrer/multiple-characters#1

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -1,5 +1,13 @@
 require("gui")
 
+
+script.on_init(function()
+	if storage.tag_character == nil then
+		storage.tag_character = {}
+		storage.character_tag = {}
+	end
+end)
+
 ---@param player LuaPlayer
 ---@param target LuaEntity?
 function switch_to(player, target)


### PR DESCRIPTION
Fixes JGDoerrer/multiple-characters#1 by adding an on_init() function that initializes the variables tag_character and character_tag. I'm sure other variables could be added to reduce other bugs also but I'll leave that to someone else since this bug is fixed.